### PR TITLE
Support reading files from local disk

### DIFF
--- a/gcs_contents_manager.py
+++ b/gcs_contents_manager.py
@@ -65,7 +65,7 @@ from notebook.services.contents.filemanager import FileContentsManager
 from notebook.services.contents.manager import ContentsManager
 from notebook.services.contents.checkpoints import Checkpoints, GenericCheckpointsMixin
 from tornado.web import HTTPError
-from traitlets import Unicode, default, observe
+from traitlets import Unicode, default
 
 from google.cloud import storage
 

--- a/gcs_contents_manager.py
+++ b/gcs_contents_manager.py
@@ -669,7 +669,7 @@ class CombinedContentsManager(ContentsManager):
       raise HTTPError(500, 'Internal server error: [{}] {}'.format(type(ex), str(ex)))
 
   def rename_file(self, old_path, new_path):
-    if old_path in ['', '/']:
+    if (old_path in ['', '/']) or (new_path in ['', '/']):
       raise HTTPError(403, 'The top-level directory is read-only')
     try:
       old_cm, old_relative_path, _ = self._content_manager_for_path(old_path)

--- a/gcs_contents_manager.py
+++ b/gcs_contents_manager.py
@@ -526,7 +526,7 @@ class CombinedContentsManager(ContentsManager):
       'GCS': gcs_cm,
     }
 
-  def _content_manager(self, path):
+  def _content_manager_for_path(self, path):
     path = path or ''
     path = path.strip('/')
     for path_prefix in self._content_managers:
@@ -537,7 +537,7 @@ class CombinedContentsManager(ContentsManager):
 
   def is_hidden(self, path):
     try:
-      cm, relative_path, path_prefix = self._content_manager(path)
+      cm, relative_path, path_prefix = self._content_manager_for_path(path)
       if cm:
         return cm.is_hidden(relative_path)
       return False
@@ -548,7 +548,7 @@ class CombinedContentsManager(ContentsManager):
 
   def file_exists(self, path):
     try:
-      cm, relative_path, path_prefix = self._content_manager(path)
+      cm, relative_path, path_prefix = self._content_manager_for_path(path)
       if cm:
         return cm.file_exists(relative_path)
       return False
@@ -561,7 +561,7 @@ class CombinedContentsManager(ContentsManager):
     if path in ['', '/']:
       return True
     try:
-      cm, relative_path, path_prefix = self._content_manager(path)
+      cm, relative_path, path_prefix = self._content_manager_for_path(path)
       if cm:
         return cm.dir_exists(relative_path)
       return False
@@ -605,7 +605,7 @@ class CombinedContentsManager(ContentsManager):
       dir_obj['last_modified'] = contents[0]['last_modified']
       return dir_obj
     try:
-      cm, relative_path, path_prefix = self._content_manager(path)
+      cm, relative_path, path_prefix = self._content_manager_for_path(path)
       if not cm:
         raise HTTPError(404, 'Not Found')
 
@@ -623,7 +623,7 @@ class CombinedContentsManager(ContentsManager):
     try:
       self.run_pre_save_hook(model=model, path=path)
 
-      cm, relative_path, path_prefix = self._content_manager(path)
+      cm, relative_path, path_prefix = self._content_manager_for_path(path)
       if not cm:
         raise HTTPError(404, 'Not Found')
       if relative_path in ['', '/']:
@@ -645,7 +645,7 @@ class CombinedContentsManager(ContentsManager):
     if path in ['', '/']:
       raise HTTPError(403, 'The top-level directory is read-only')
     try:
-      cm, relative_path, path_prefix = self._content_manager(path)
+      cm, relative_path, path_prefix = self._content_manager_for_path(path)
       if not cm:
         raise HTTPError(404, 'Not Found')
       if relative_path in ['', '/']:
@@ -672,13 +672,13 @@ class CombinedContentsManager(ContentsManager):
     if old_path in ['', '/']:
       raise HTTPError(403, 'The top-level directory is read-only')
     try:
-      old_cm, old_relative_path, _ = self._content_manager(old_path)
+      old_cm, old_relative_path, _ = self._content_manager_for_path(old_path)
       if not old_cm:
         raise HTTPError(404, 'Not Found')
       if old_relative_path in ['', '/']:
         raise HTTPError(403, 'The top-level directory contents are read-only')
 
-      new_cm, new_relative_path, _ = self._content_manager(new_path)
+      new_cm, new_relative_path, _ = self._content_manager_for_path(new_path)
       if not new_cm:
         raise HTTPError(404, 'Not Found')
       if new_relative_path in ['', '/']:

--- a/gcs_contents_manager.py
+++ b/gcs_contents_manager.py
@@ -464,64 +464,46 @@ class CombinedCheckpointsManager(GenericCheckpointsMixin, Checkpoints):
       if path == path_prefix or path.startswith(path_prefix+'/'):
         relative_path = path[len(path_prefix):]
         return self._content_managers[path_prefix].checkpoints, relative_path
-    return None, path
+    raise HTTPError(400, 'Unsupported checkpoint path: {}'.format(path))
 
   def checkpoint_path(self, checkpoint_id, path):
     checkpoint_manager, relative_path = self._checkpoint_manager_for_path(path)
-    if not checkpoint_manager:
-      raise HTTPError(500, 'Unsupported checkpoint path: {}'.format(path))
     return checkpoint_manager.checkpoint_path(checkpoint_id, relative_path)
 
   def checkpoint_blob(self, checkpoint_id, path, create_if_missing=False):
     checkpoint_manager, relative_path = self._checkpoint_manager_for_path(path)
-    if not checkpoint_manager:
-      raise HTTPError(500, 'Unsupported checkpoint path: {}'.format(path))
     return checkpoint_manager.checkpoint_blob(
         checkpoint_id, relative_path, create_if_missing=create_if_missing)
 
   def create_file_checkpoint(self, content, format, path):
     checkpoint_manager, relative_path = self._checkpoint_manager_for_path(path)
-    if not checkpoint_manager:
-      raise HTTPError(500, 'Unsupported checkpoint path: {}'.format(path))
     return checkpoint_manager.create_file_checkpoint(content, format, relative_path)
 
   def create_notebook_checkpoint(self, nb, path):
     checkpoint_manager, relative_path = self._checkpoint_manager_for_path(path)
-    if not checkpoint_manager:
-      raise HTTPError(500, 'Unsupported checkpoint path: {}'.format(path))
     return checkpoint_manager.create_notebook_checkpoint(nb, relative_path)
 
   def get_file_checkpoint(self, checkpoint_id, path):
     checkpoint_manager, relative_path = self._checkpoint_manager_for_path(path)
-    if not checkpoint_manager:
-      raise HTTPError(500, 'Unsupported checkpoint path: {}'.format(path))
     return checkpoint_manager.get_file_checkpoint(checkpoint_id, relative_path)
 
   def get_notebook_checkpoint(self, checkpoint_id, path):
     checkpoint_manager, relative_path = self._checkpoint_manager_for_path(path)
-    if not checkpoint_manager:
-      raise HTTPError(500, 'Unsupported checkpoint path: {}'.format(path))
     return checkpoint_manager.get_notebook_checkpoint(checkpoint_id, relative_path)
 
   def delete_checkpoint(self, checkpoint_id, path):
     checkpoint_manager, relative_path = self._checkpoint_manager_for_path(path)
-    if not checkpoint_manager:
-      raise HTTPError(500, 'Unsupported checkpoint path: {}'.format(path))
     return checkpoint_manager.delete_checkpoint(checkpoint_id, relative_path)
 
   def list_checkpoints(self, path):
     checkpoint_manager, relative_path = self._checkpoint_manager_for_path(path)
-    if not checkpoint_manager:
-      raise HTTPError(500, 'Unsupported checkpoint path: {}'.format(path))
     return checkpoint_manager.list_checkpoints(relative_path)
 
   def rename_checkpoint(self, checkpoint_id, old_path, new_path):
     checkpoint_manager, old_relative_path = self._checkpoint_manager_for_path(old_path)
-    if not checkpoint_manager:
-      raise HTTPError(500, 'Unsupported checkpoint path: {}'.format(old_path))
     new_checkpoint_manager, new_relative_path = self._checkpoint_manager_for_path(new_path)
     if new_checkpoint_manager != checkpoint_manager:
-      raise HTTPError(500, 'Unsupported rename: {}->{}'.format(old_path, new_path))
+      raise HTTPError(400, 'Unsupported rename across file systems: {}->{}'.format(old_path, new_path))
     return checkpoint_manager.rename_checkpoint(checkpoint_id, old_relative_path, new_relative_path)
 
 


### PR DESCRIPTION
This PR adds a feature where the GCS contents manager can run alongside the standard file-based contents manager.

This works by creating two virtual, top-level directories, `GCS` and `Local Disk`. The `GCS` directory maps to the GCS contents manager, and the `Local Disk` directory maps to the file-based contents manager.

That works well enough for reading and writing files from either GCS or local disk, but there is a subtle issue that can come up with JupyterLab if you use any widgets that use the FileBrowser's current path (such as the jupyterlab_git extension).

Those extensions might assume that the API paths being used map to an actual path on disk relative to the content manager's `root_dir` property.

To accommodate this, the `CombinedContentsManager` class has its own `root_dir` property that is separate from the `FileContentsManager` class. User's can set the `c.FileContentsManager.root_dir` config entry to their real notebooks directory, and then create a symlink somewhere on their disk to that directory named `Local Disk` and make the parent directory of the symlink the value of the `c.CombinedContentsManager.root_dir` config entry.

This change fixes #1 