### PR TITLE
Don't load file contents when getting a directory

### DIFF
--- a/gcs_contents_manager.py
+++ b/gcs_contents_manager.py
@@ -323,7 +323,7 @@ class GCSContentsManager(ContentsManager):
         if first_slash < 0:
           child_path = posixpath.join(normalized_path, suffix)
           add_child(suffix,
-                    self._blob_model(child_path, b),
+                    self._blob_model(child_path, b, content=False),
                     override_existing=True)
         else:
           subdir = suffix[0:first_slash]


### PR DESCRIPTION
This change avoids loading the contents of all files under a directory when listing that directory. This is consistent with the behavior of the default FileContentsManager.
(https://github.com/jupyter/notebook/blob/master/notebook/services/contents/filemanager.py#L336)